### PR TITLE
React-Native NetInfo -> React-Native-Community/NetInfo

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   },
   "homepage": "https://github.com/calvium/react-native-redux-connectivity#readme",
   "peerDependencies": {
-    "react-native": ">=0.48.0"
+    "react-native": ">=0.48.0",
+    "@react-native-community/netinfo": "^1.4.1"
   },
   "devDependencies": {
     "eslint": "^3.19.0",

--- a/src/NetworkMonitor.js
+++ b/src/NetworkMonitor.js
@@ -1,4 +1,4 @@
-import {NetInfo} from 'react-native';
+import NetInfo from '@react-native-community/netinfo';
 import {setNetworkAction} from './redux';
 
 /**


### PR DESCRIPTION
Moving away from the depreciated React-Native [NetInfo](https://facebook.github.io/react-native/docs/netinfo) library to [@react-native-community/netinfo](https://github.com/react-native-community/react-native-netinfo)