### PR TITLE
Deprecated API warning removed

### DIFF
--- a/src/NetworkMonitor.js
+++ b/src/NetworkMonitor.js
@@ -34,7 +34,7 @@ class NetworkMonitor {
       this.dispatch(setNetworkAction(connected, type, effectiveType));
     }
 
-    NetInfo.getConnectionInfo().then(this.handleConnectivityChange);
+    NetInfo.fetch().then(this.handleConnectivityChange);
 
     if (!store || !store.dispatch) {
       throw new Error('Pass your store instance into `new NetworkMonitor(store)` to use');
@@ -43,11 +43,11 @@ class NetworkMonitor {
   }
 
   start() {
-    NetInfo.addEventListener('connectionChange', this.handleConnectivityChange);
+    NetInfo.addEventListener(this.handleConnectivityChange);
   }
 
   stop() {
-    NetInfo.removeEventListener('connectionChange', this.handleConnectivityChange);
+    NetInfo.removeEventListener(this.handleConnectivityChange);
   }
 }
 


### PR DESCRIPTION
getConnectionInfo method changed to fetch
eventListener first parameter "listenerName" removed from API call
<img width="341" alt="Screenshot 2019-11-29 at 4 12 42 PM" src="https://user-images.githubusercontent.com/41570871/70210181-12e85b80-1758-11ea-97b3-d4cdbc7815d7.png">
